### PR TITLE
Fix SwiftUI Previews in Xcode 14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,6 @@ let package = Package(
     products: [
         .library(
             name: "PINRemoteImage",
-            type: .static,
             targets: ["PINRemoteImage"]),
     ],
     dependencies: [


### PR DESCRIPTION
This fixes previews for Xcode 14.

Got the fix from here: https://github.com/mix6s/PINRemoteImage/commit/a9cc7e20380b67af292c3ff7c51d84568fd6244d